### PR TITLE
fix token filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parifi/synthetix-sdk-ts",
-  "version": "0.4.3-dev",
+  "version": "0.4.4-dev",
   "description": "A Typescript SDK for interactions with the Synthetix protocol",
   "files": [
     "dist",

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -208,15 +208,11 @@ export class Contracts {
 
   public async getCollateralInstance(symbol: string) {
     try {
-      symbol = symbol.toUpperCase();
       const meta = await dynamicImportMeta(this.sdk.rpcConfig.chainId, this.sdk.rpcConfig.preset);
 
       const contracts = Object.keys(meta.contracts);
-      const contract = contracts.find(
-        (contract) => contract.toLowerCase() === `CollateralToken_${symbol}`.toLowerCase(),
-      );
-
-      console.log('=== contracts', contracts, contract);
+      const contract = contracts.find((contract) => contract.toLowerCase().includes(symbol.toLowerCase()));
+      console.log('=== contracts', contracts, symbol, contract);
 
       // @ts-expect-error correct type
       const address = meta.contracts[contract as string] as Hex;


### PR DESCRIPTION
testnet tokens are prefixed by f (ex: fsol, fusde) and main tokens doestn have this prefix (usde, sol) so we are simplifying the way on how we get the token from the contracts name